### PR TITLE
Add an `ecrecover` check to calls to `isValidSignature`

### DIFF
--- a/src/EIP7702Proxy.sol
+++ b/src/EIP7702Proxy.sol
@@ -11,6 +11,11 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 /// @dev Implements ERC-1967, but with an initial implementation.
 /// @dev Guards the initializer function, requiring a signed payload by the wallet to call it.
 contract EIP7702Proxy is Proxy {
+    // ERC1271 interface constants
+    bytes4 internal constant ERC1271_MAGIC_VALUE = 0x1626ba7e;
+    bytes4 internal constant ERC1271_ISVALIDSIGNATURE_SELECTOR = 0x1626ba7e;
+    bytes4 internal constant ERC1271_FAIL_VALUE = 0xffffffff;
+
     address immutable proxy;
     address immutable initialImplementation;
     bytes4 immutable guardedInitializer;
@@ -56,6 +61,46 @@ contract EIP7702Proxy is Proxy {
     function _fallback() internal override {
         // block guarded initializer from being called
         if (msg.sig == guardedInitializer) revert InvalidInitializer();
+
+        // Special handling for isValidSignature
+        if (msg.sig == ERC1271_ISVALIDSIGNATURE_SELECTOR) {
+            (bytes32 hash, bytes memory signature) = abi.decode(
+                msg.data[4:],
+                (bytes32, bytes)
+            );
+
+            // First try delegatecall to implementation
+            (bool success, bytes memory result) = _implementation()
+                .delegatecall(msg.data);
+
+            // If delegatecall succeeded and returned magic value, return that
+            if (
+                success &&
+                result.length == 32 &&
+                abi.decode(result, (bytes4)) == ERC1271_MAGIC_VALUE
+            ) {
+                assembly {
+                    mstore(0, ERC1271_MAGIC_VALUE)
+                    return(0, 32)
+                }
+            }
+
+            // Otherwise try ecrecover
+            address recovered = ECDSA.recover(hash, signature);
+            if (recovered == address(this)) {
+                assembly {
+                    mstore(0, ERC1271_MAGIC_VALUE)
+                    return(0, 32)
+                }
+            }
+
+            // If all checks fail, return failure value
+            assembly {
+                mstore(0, ERC1271_FAIL_VALUE)
+                return(0, 32)
+            }
+        }
+
         _delegate(_implementation());
     }
 }

--- a/test/EIP7702Proxy/isValidSignature.t.sol
+++ b/test/EIP7702Proxy/isValidSignature.t.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.23;
+
+import {EIP7702ProxyBase} from "../base/EIP7702ProxyBase.sol";
+import {EIP7702Proxy} from "../../src/EIP7702Proxy.sol";
+import {CoinbaseSmartWallet} from "../../lib/smart-wallet/src/CoinbaseSmartWallet.sol";
+import {ECDSA} from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
+
+contract IsValidSignatureTest is EIP7702ProxyBase {
+    bytes4 constant ERC1271_MAGIC_VALUE = 0x1626ba7e;
+    bytes4 constant ERC1271_FAIL_VALUE = 0xffffffff;
+
+    bytes32 testHash;
+    CoinbaseSmartWallet wallet;
+
+    function setUp() public override {
+        super.setUp();
+
+        // Initialize the wallet with a contract owner
+        bytes memory initArgs = _createInitArgs(_newOwner);
+        bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);
+        vm.prank(_eoa);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+
+        wallet = CoinbaseSmartWallet(payable(_eoa));
+        testHash = keccak256("test message");
+
+        // Verify owner was set correctly
+        assertTrue(
+            wallet.isOwnerAddress(_newOwner),
+            "New owner should be set after initialization"
+        );
+        assertEq(
+            wallet.ownerAtIndex(0),
+            abi.encode(_newOwner),
+            "Owner at index 0 should be new owner"
+        );
+    }
+
+    function testValidContractOwnerSignature() public {
+        // Create signature from contract owner
+        bytes memory signature = _createOwnerSignature(
+            testHash,
+            address(wallet),
+            _NEW_OWNER_PRIVATE_KEY,
+            0 // First owner
+        );
+
+        bytes4 result = wallet.isValidSignature(testHash, signature);
+        assertEq(
+            result,
+            ERC1271_MAGIC_VALUE,
+            "Should accept valid contract owner signature"
+        );
+    }
+
+    function testValidEOASignature() public {
+        // Create signature from original EOA
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(_EOA_PRIVATE_KEY, testHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        bytes4 result = wallet.isValidSignature(testHash, signature);
+        assertEq(
+            result,
+            ERC1271_MAGIC_VALUE,
+            "Should accept valid EOA signature"
+        );
+    }
+
+    function testInvalidEOASignature() public {
+        // Create signature from wrong EOA
+        uint256 wrongPk = 0xB0B;
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongPk, testHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        bytes4 result = wallet.isValidSignature(testHash, signature);
+        assertEq(
+            result,
+            ERC1271_FAIL_VALUE,
+            "Should reject invalid EOA signature"
+        );
+    }
+
+    function testInvalidOwnerSignature() public {
+        // Create a valid format signature but with wrong signer
+        uint256 wrongPk = 0xBADBAD; // Different from both EOA and new owner (0xB0B)
+        bytes memory signature = _createOwnerSignature(
+            testHash,
+            address(wallet),
+            wrongPk,
+            0
+        );
+
+        bytes4 result = wallet.isValidSignature(testHash, signature);
+        assertEq(
+            result,
+            ERC1271_FAIL_VALUE,
+            "Should reject signature from non-owner"
+        );
+    }
+
+    function testEmptySignature() public {
+        bytes memory emptySignature = "";
+
+        vm.expectRevert();
+        bytes4 result = wallet.isValidSignature(testHash, emptySignature);
+    }
+}

--- a/test/base/EIP7702ProxyBase.sol
+++ b/test/base/EIP7702ProxyBase.sol
@@ -15,42 +15,39 @@ abstract contract EIP7702ProxyBase is Test {
     // Test accounts
     uint256 internal constant _EOA_PRIVATE_KEY = 0xA11CE;
     address payable internal _eoa;
-    
+
     uint256 internal constant _NEW_OWNER_PRIVATE_KEY = 0xB0B;
     address payable internal _newOwner;
-    
+
     // Contracts
     EIP7702Proxy internal _proxy;
     CoinbaseSmartWallet internal _implementation;
-    
+
     // Common test data
     bytes4 internal _initSelector;
-    
+
     function setUp() public virtual {
         // Set up test accounts
         _eoa = payable(vm.addr(_EOA_PRIVATE_KEY));
         vm.deal(_eoa, 100 ether);
-        
+
         _newOwner = payable(vm.addr(_NEW_OWNER_PRIVATE_KEY));
         vm.deal(_newOwner, 100 ether);
-        
+
         // Deploy implementation
         _implementation = new CoinbaseSmartWallet();
         _initSelector = CoinbaseSmartWallet.initialize.selector;
-        
+
         // Deploy proxy normally first to get the correct immutable values
-        _proxy = new EIP7702Proxy(
-            address(_implementation),
-            _initSelector
-        );
-        
+        _proxy = new EIP7702Proxy(address(_implementation), _initSelector);
+
         // Get the proxy's runtime code
         bytes memory proxyCode = address(_proxy).code;
-        
+
         // Etch the proxy code at the EOA's address to simulate EIP-7702 upgrade
         vm.etch(_eoa, proxyCode);
     }
-    
+
     /**
      * @dev Helper to generate initialization signature
      * @param signerPk Private key of the signer
@@ -66,15 +63,72 @@ abstract contract EIP7702ProxyBase is Test {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPk, initHash);
         return abi.encodePacked(r, s, v);
     }
-    
+
     /**
      * @dev Helper to create initialization args with a single owner
      * @param owner Address to set as owner
      * @return Encoded initialization arguments
      */
-    function _createInitArgs(address owner) internal pure returns (bytes memory) {
+    function _createInitArgs(
+        address owner
+    ) internal pure returns (bytes memory) {
         bytes[] memory owners = new bytes[](1);
         owners[0] = abi.encode(owner);
         return abi.encode(owners);
     }
-} 
+
+    function _sign(
+        uint256 pk,
+        bytes32 hash
+    ) internal pure returns (bytes memory signature) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, hash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _createOwnerSignature(
+        bytes32 message,
+        address smartWallet,
+        uint256 ownerPk,
+        uint256 ownerIndex
+    ) internal view returns (bytes memory) {
+        bytes32 replaySafeHash = CoinbaseSmartWallet(payable(smartWallet))
+            .replaySafeHash(message);
+        bytes memory signature = _sign(ownerPk, replaySafeHash);
+        bytes memory wrappedSignature = _applySignatureWrapper(
+            ownerIndex,
+            signature
+        );
+        return wrappedSignature;
+    }
+
+    function _applySignatureWrapper(
+        uint256 ownerIndex,
+        bytes memory signatureData
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encode(
+                CoinbaseSmartWallet.SignatureWrapper(ownerIndex, signatureData)
+            );
+    }
+
+    /**
+     * @dev Helper to deploy a proxy and etch its code at a target address
+     * @param target The address where the proxy code should be etched
+     * @return The target address (for convenience)
+     */
+    function _deployProxy(address target) internal returns (address) {
+        // Deploy proxy normally first to get the correct immutable values
+        EIP7702Proxy proxy = new EIP7702Proxy(
+            address(_implementation),
+            _initSelector
+        );
+
+        // Get the proxy's runtime code
+        bytes memory proxyCode = address(proxy).code;
+
+        // Etch the proxy code at the target address
+        vm.etch(target, proxyCode);
+
+        return target;
+    }
+}


### PR DESCRIPTION
The EF points out that for upgraded EOAs that have smart contract code and conform to ERC-1271, we need to also honor ecrecover checks for EOA signatures. This PR introduces a change to the proxy contract that performs an additional `ecrecover` check if the call to `isValidSignature` on the smart wallet fails. 