### PR TITLE
Set ERC-1967 implementation slot and emit event during `initialize`

### DIFF
--- a/src/EIP7702Proxy.sol
+++ b/src/EIP7702Proxy.sol
@@ -90,12 +90,14 @@ contract EIP7702Proxy is Proxy {
                 }
             }
 
-            // Otherwise try ecrecover
-            address recovered = ECDSA.recover(hash, signature);
-            if (recovered == address(this)) {
-                assembly {
-                    mstore(0, ERC1271_MAGIC_VALUE)
-                    return(0, 32)
+            // Only try ECDSA if signature is the right length (65 bytes)
+            if (signature.length == 65) {
+                address recovered = ECDSA.recover(hash, signature);
+                if (recovered == address(this)) {
+                    assembly {
+                        mstore(0, ERC1271_MAGIC_VALUE)
+                        return(0, 32)
+                    }
                 }
             }
 

--- a/src/EIP7702Proxy.sol
+++ b/src/EIP7702Proxy.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
-import {Proxy} from "@openzeppelin/contracts/proxy/Proxy.sol";
-import {ERC1967Utils} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
-import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {Proxy} from "openzeppelin-contracts/contracts/proxy/Proxy.sol";
+import {ERC1967Utils} from "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Utils.sol";
+import {ECDSA} from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
+import {Address} from "openzeppelin-contracts/contracts/utils/Address.sol";
 
 /// @notice Proxy contract designed for EIP-7702 smart accounts.
 ///
@@ -14,6 +14,8 @@ contract EIP7702Proxy is Proxy {
     address immutable proxy;
     address immutable initialImplementation;
     bytes4 immutable guardedInitializer;
+
+    event Upgraded(address indexed implementation);
 
     error InvalidSignature();
     error InvalidInitializer();
@@ -38,6 +40,9 @@ contract EIP7702Proxy is Proxy {
         address implementation = _implementation();
         if (implementation != initialImplementation)
             revert InvalidImplementation();
+
+        // Set the ERC-1967 implementation slot and emit Upgraded event
+        ERC1967Utils.upgradeToAndCall(initialImplementation, "");
 
         Address.functionDelegateCall(
             initialImplementation,

--- a/test/EIP7702Proxy/initialize.t.sol
+++ b/test/EIP7702Proxy/initialize.t.sol
@@ -5,13 +5,13 @@ import {EIP7702ProxyBase} from "../base/EIP7702ProxyBase.sol";
 import {EIP7702Proxy} from "../../src/EIP7702Proxy.sol";
 import {CoinbaseSmartWallet} from "../../lib/smart-wallet/src/CoinbaseSmartWallet.sol";
 import {ECDSA} from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
+import {ERC1967Utils} from "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Utils.sol";
 
 contract InitializeTest is EIP7702ProxyBase {
     function testSucceedsWithValidSignature() public {
         bytes memory initArgs = _createInitArgs(_newOwner);
         bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);
 
-        vm.prank(_eoa);
         EIP7702Proxy(_eoa).initialize(initArgs, signature);
 
         // Verify initialization through implementation at the EOA's address
@@ -26,7 +26,6 @@ contract InitializeTest is EIP7702ProxyBase {
         bytes memory initArgs = _createInitArgs(_newOwner);
         bytes memory signature = hex"deadbeef"; // Invalid signature
 
-        vm.prank(_eoa);
         vm.expectRevert(); // Should revert with signature verification error
         EIP7702Proxy(_eoa).initialize(initArgs, signature);
     }
@@ -40,7 +39,6 @@ contract InitializeTest is EIP7702ProxyBase {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongPk, initHash);
         bytes memory signature = abi.encodePacked(r, s, v);
 
-        vm.prank(_eoa);
         vm.expectRevert(); // Should revert with signature verification error
         EIP7702Proxy(_eoa).initialize(initArgs, signature);
     }
@@ -49,12 +47,33 @@ contract InitializeTest is EIP7702ProxyBase {
         bytes memory initArgs = _createInitArgs(_newOwner);
         bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);
 
-        vm.prank(_eoa);
         EIP7702Proxy(_eoa).initialize(initArgs, signature);
 
         // Try to initialize again
-        vm.prank(_eoa);
         vm.expectRevert(CoinbaseSmartWallet.Initialized.selector);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+    }
+
+    function testSetsERC1967ImplementationSlot() public {
+        bytes memory initArgs = _createInitArgs(_newOwner);
+        bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);
+
+        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+
+        address storedImpl = _getERC1967Implementation(address(_eoa));
+        assertEq(
+            storedImpl,
+            address(_implementation),
+            "ERC1967 implementation slot should store implementation address"
+        );
+    }
+
+    function testEmitsUpgradedEvent() public {
+        bytes memory initArgs = _createInitArgs(_newOwner);
+        bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);
+
+        vm.expectEmit(true, false, false, false, address(_eoa));
+        emit EIP7702Proxy.Upgraded(address(_implementation));
         EIP7702Proxy(_eoa).initialize(initArgs, signature);
     }
 }

--- a/test/EIP7702Proxy/isValidSignature.t.sol
+++ b/test/EIP7702Proxy/isValidSignature.t.sol
@@ -102,7 +102,11 @@ contract IsValidSignatureTest is EIP7702ProxyBase {
     function testEmptySignature() public {
         bytes memory emptySignature = "";
 
-        vm.expectRevert();
         bytes4 result = wallet.isValidSignature(testHash, emptySignature);
+        assertEq(
+            result,
+            ERC1271_FAIL_VALUE,
+            "Should reject empty signature"
+        );
     }
 }

--- a/test/base/EIP7702ProxyBase.sol
+++ b/test/base/EIP7702ProxyBase.sol
@@ -12,6 +12,10 @@ import {ECDSA} from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.s
  *      This contract should not contain any actual tests.
  */
 abstract contract EIP7702ProxyBase is Test {
+    // Add ERC1967 implementation slot constant
+    bytes32 internal constant IMPLEMENTATION_SLOT = 
+        0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
     // Test accounts
     uint256 internal constant _EOA_PRIVATE_KEY = 0xA11CE;
     address payable internal _eoa;
@@ -76,5 +80,14 @@ abstract contract EIP7702ProxyBase is Test {
         bytes[] memory owners = new bytes[](1);
         owners[0] = abi.encode(owner);
         return abi.encode(owners);
+    }
+
+    /**
+     * @dev Helper to read the implementation address from ERC1967 storage slot
+     * @param proxy Address of the proxy contract to read from
+     * @return The implementation address stored in the ERC1967 slot
+     */
+    function _getERC1967Implementation(address proxy) internal view returns (address) {
+        return address(uint160(uint256(vm.load(proxy, IMPLEMENTATION_SLOT))));
     }
 } 


### PR DESCRIPTION
As mentioned in the motivation of [ERC-1967](https://eips.ethereum.org/EIPS/eip-1967), having a standard for storing the implementation pointer in a proxy system makes it possible for tools like block explorers to build on this information. Therefore, we suggest setting the implementation slot defined in the standard when the proxy is initialized. Because EIP-7702 doesn't allow for initialization calldata during the authorization/upgrade process, we can't set the implementation storage at the time the EOA delegation designation is set. Therefore, we set it during initialization. Another benefit of setting the slot is the emission of the `Upgraded` event, which will allow us to track EOA upgrades to CBSW with event data.