### PR TITLE
Add `receive` function

### DIFF
--- a/src/EIP7702Proxy.sol
+++ b/src/EIP7702Proxy.sol
@@ -144,4 +144,6 @@ contract EIP7702Proxy is Proxy {
     function _implementation() internal view override returns (address) {
         return ERC1967Utils.getImplementation();
     }
+
+    receive() external payable {}
 }

--- a/src/EIP7702Proxy.sol
+++ b/src/EIP7702Proxy.sol
@@ -145,5 +145,6 @@ contract EIP7702Proxy is Proxy {
         return ERC1967Utils.getImplementation();
     }
 
+    /// @notice Allow the account to receive ETH under any circumstances
     receive() external payable {}
 }


### PR DESCRIPTION
It turns out the need for an explicit `receive` function on the proxy is important in our current design iteration (and not only to silence compiler warnings!). Due to blocking calls via the `fallback` before the proxy is initialized, it turns out that even direct ETH transfers were hitting the guarded fallback, and would revert if the proxy's not initialized. We don't ever want an account to be unpayable, even in the presumably non-existent period between delegating and initializing, which are not *technically* atomic and leave open the possibility in some case of a delegated EOA to our EIP7702Proxy that is not yet initialized. In this state and account would not be able to receive pure ETH transfers until initialized, which is bad!